### PR TITLE
fix: respect rule type for sub-rules in segment evaluation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/engine_tests/engine-test-data"]
 	path = tests/engine_tests/engine-test-data
 	url = https://github.com/flagsmith/engine-test-data.git
-	branch = v3.5.0
+	branch = v3.7.0

--- a/src/engine_eval/segment_evaluator.rs
+++ b/src/engine_eval/segment_evaluator.rs
@@ -37,14 +37,43 @@ fn context_matches_segment_rule(
         return false;
     }
 
-    // Check nested rules
-    for nested_rule in &rule.rules {
-        if !context_matches_segment_rule(ec, nested_rule, segment_key) {
-            return false;
+    // Check nested rules using rule type
+    if rule.rules.is_empty() {
+        return true;
+    }
+
+    matches_sub_rules_by_rule_type(ec, &rule.rules, &rule.rule_type, segment_key)
+}
+
+fn matches_sub_rules_by_rule_type(
+    ec: &EngineEvaluationContext,
+    sub_rules: &[SegmentRule],
+    rule_type: &SegmentRuleType,
+    segment_key: &str,
+) -> bool {
+    for sub_rule in sub_rules {
+        let sub_rule_matches = context_matches_segment_rule(ec, sub_rule, segment_key);
+
+        match rule_type {
+            SegmentRuleType::All => {
+                if !sub_rule_matches {
+                    return false;
+                }
+            }
+            SegmentRuleType::None => {
+                if sub_rule_matches {
+                    return false;
+                }
+            }
+            SegmentRuleType::Any => {
+                if sub_rule_matches {
+                    return true;
+                }
+            }
         }
     }
 
-    true
+    *rule_type != SegmentRuleType::Any
 }
 
 /// Checks if conditions match according to the rule type

--- a/src/engine_eval/segment_evaluator.rs
+++ b/src/engine_eval/segment_evaluator.rs
@@ -51,29 +51,14 @@ fn matches_sub_rules_by_rule_type(
     rule_type: &SegmentRuleType,
     segment_key: &str,
 ) -> bool {
-    for sub_rule in sub_rules {
-        let sub_rule_matches = context_matches_segment_rule(ec, sub_rule, segment_key);
-
-        match rule_type {
-            SegmentRuleType::All => {
-                if !sub_rule_matches {
-                    return false;
-                }
-            }
-            SegmentRuleType::None => {
-                if sub_rule_matches {
-                    return false;
-                }
-            }
-            SegmentRuleType::Any => {
-                if sub_rule_matches {
-                    return true;
-                }
-            }
-        }
+    let mut results = sub_rules
+        .iter()
+        .map(|sr| context_matches_segment_rule(ec, sr, segment_key));
+    match rule_type {
+        SegmentRuleType::All => results.all(|r| r),
+        SegmentRuleType::Any => results.any(|r| r),
+        SegmentRuleType::None => !results.any(|r| r),
     }
-
-    *rule_type != SegmentRuleType::Any
 }
 
 /// Checks if conditions match according to the rule type

--- a/src/segments/evaluator.rs
+++ b/src/segments/evaluator.rs
@@ -41,36 +41,34 @@ pub fn evaluate_identity_in_segment(
             .all(|result| result)
 }
 
+fn matches_by_rule_type(rule_type: &str, mut results: impl Iterator<Item = bool>) -> bool {
+    match rule_type {
+        constants::ANY_RULE => results.any(|r| r),
+        constants::ALL_RULE => results.all(|r| r),
+        constants::NONE_RULE => !results.any(|r| r),
+        _ => false,
+    }
+}
+
 fn traits_match_segment_rule(
     identity_traits: &Vec<identities::Trait>,
     rule: &SegmentRule,
     segment_id: &str,
     identity_id: &str,
 ) -> bool {
-    let mut rules_iterator = rule.conditions.iter().map(|condition| {
+    let conditions_iterator = rule.conditions.iter().map(|condition| {
         traits_match_segment_condition(&identity_traits, condition, segment_id, identity_id)
     });
-    let matches_condtion = match rule.segment_rule_type.as_str() {
-        constants::ANY_RULE => rules_iterator.any(|result| result == true),
-        constants::ALL_RULE => rules_iterator.all(|result| result == true),
-        constants::NONE_RULE => !rules_iterator.any(|result| result),
-        _ => false,
-    };
-    if !matches_condtion {
+    if !matches_by_rule_type(rule.segment_rule_type.as_str(), conditions_iterator) {
         return false;
     }
     if rule.rules.is_empty() {
         return true;
     }
-    let mut sub_rules_iterator = rule.rules.iter().map(|sub_rule| {
+    let sub_rules_iterator = rule.rules.iter().map(|sub_rule| {
         traits_match_segment_rule(&identity_traits, sub_rule.as_ref(), segment_id, identity_id)
     });
-    match rule.segment_rule_type.as_str() {
-        constants::ANY_RULE => sub_rules_iterator.any(|result| result),
-        constants::ALL_RULE => sub_rules_iterator.all(|result| result),
-        constants::NONE_RULE => !sub_rules_iterator.any(|result| result),
-        _ => false,
-    }
+    matches_by_rule_type(rule.segment_rule_type.as_str(), sub_rules_iterator)
 }
 
 fn traits_match_segment_condition(

--- a/src/segments/evaluator.rs
+++ b/src/segments/evaluator.rs
@@ -53,17 +53,24 @@ fn traits_match_segment_rule(
     let matches_condtion = match rule.segment_rule_type.as_str() {
         constants::ANY_RULE => rules_iterator.any(|result| result == true),
         constants::ALL_RULE => rules_iterator.all(|result| result == true),
-        constants::NONE_RULE => true,
+        constants::NONE_RULE => !rules_iterator.any(|result| result),
         _ => false,
     };
-    return matches_condtion
-        && rule
-            .rules
-            .iter()
-            .map(|rule| {
-                traits_match_segment_rule(&identity_traits, rule.as_ref(), segment_id, identity_id)
-            })
-            .all(|result| result == true);
+    if !matches_condtion {
+        return false;
+    }
+    if rule.rules.is_empty() {
+        return true;
+    }
+    let mut sub_rules_iterator = rule.rules.iter().map(|sub_rule| {
+        traits_match_segment_rule(&identity_traits, sub_rule.as_ref(), segment_id, identity_id)
+    });
+    match rule.segment_rule_type.as_str() {
+        constants::ANY_RULE => sub_rules_iterator.any(|result| result),
+        constants::ALL_RULE => sub_rules_iterator.all(|result| result),
+        constants::NONE_RULE => !sub_rules_iterator.any(|result| result),
+        _ => false,
+    }
 }
 
 fn traits_match_segment_condition(


### PR DESCRIPTION
## Summary
- Bumped engine-test-data submodule from v3.5.0 to v3.7.0
- Fixed segment evaluation in both evaluator paths:
  - **New context-based evaluator** (`engine_eval/segment_evaluator.rs`): sub-rules now respect the parent rule's type (ANY/ALL/NONE) instead of hardcoding ALL
  - **Legacy evaluator** (`segments/evaluator.rs`): same sub-rules fix + fixed NONE rule type for conditions (was hardcoded to `true`)

Equivalent fix to [flagsmith-engine#313](https://github.com/Flagsmith/flagsmith-engine/pull/313).

## Test plan
- [x] Bumped engine-test-data to v3.7.0 (includes new sub-rule type test cases)
- [x] Verified tests fail before the fix
- [x] Applied the fix
- [x] Verified all tests pass after the fix (156 tests: 134 unit + 22 integration)