### PR TITLE
ci: track engine-test-data semver tags via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended", ":semanticCommitScopeDisabled"],
+    "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
+    "semanticCommitType": "deps",
+    "git-submodules": { "enabled": true },
+    "packageRules": [
+        {
+            "matchUpdateTypes": [
+                "major",
+                "minor",
+                "patch",
+                "digest",
+                "pin",
+                "rollback",
+                "bump",
+                "replacement",
+                "lockFileMaintenance"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["git-submodules"],
+            "versioning": "semver-coerced",
+            "enabled": true
+        }
+    ]
+}


### PR DESCRIPTION
## Problem

`flagsmith-rust-flag-engine` tracks the `engine-test-data` submodule (`.gitmodules` `branch = v3.7.0`) but has **no Renovate config**, so Renovate never runs the `git-submodules` manager here and the submodule is only ever bumped manually.

Even where a config exists across the other SDKs, the `git-submodules` manager defaults to `versioning: "git"`, which treats the `branch = v3.x.y` value as an opaque ref and never proposes newer tags.

## Fix

Add a Renovate config modeled on the other Flagsmith SDKs: disable proactive bumps by default, re-enable the `git-submodules` manager, and set `versioning: "semver-coerced"` so Renovate ranks the semver tags and opens bump PRs (e.g. `v3.7.0` → `v3.10.0`).
